### PR TITLE
Add equal?/2

### DIFF
--- a/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
@@ -68,7 +68,7 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't parse value #{inspect value}"}
+        :error -> {:error, message: "Couldn't parse value #{inspect(value)}"}
       end
     end
 
@@ -91,6 +91,14 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     # New for ecto_sql 3.2
     def embed_as(_), do: :self
+
+    def equal?(%Cldr.Unit{} = term1, %Cldr.Unit{} = term2) do
+      case Cldr.Unit.compare(term1, term2) do
+        :eq -> true
+        _ -> false
+      end
+    end
+
     def equal?(term1, term2), do: term1 == term2
   end
 end

--- a/lib/cldr/unit/ecto/unit_ecto_map_type.ex
+++ b/lib/cldr/unit/ecto/unit_ecto_map_type.ex
@@ -18,11 +18,11 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     @behaviour Ecto.Type
 
-    defdelegate cast(money), to: Cldr.Unit.Ecto.Composite.Type
+    defdelegate cast(unit), to: Cldr.Unit.Ecto.Composite.Type
 
     # New for ecto_sql 3.2
-    defdelegate  embed_as(term), to: Cldr.Unit.Ecto.Composite.Type
-    defdelegate  equal?(term1, term2), to: Cldr.Unit.Ecto.Composite.Type
+    defdelegate embed_as(term), to: Cldr.Unit.Ecto.Composite.Type
+    defdelegate equal?(term1, term2), to: Cldr.Unit.Ecto.Composite.Type
 
     def type() do
       :map
@@ -67,13 +67,11 @@ if Code.ensure_loaded?(Ecto.Type) do
     end
 
     def dump(%Cldr.Unit{unit: unit_name, value: value}) do
-      {:ok,
-        %{"unit" => to_string(unit_name), "value" => to_string(value)}}
+      {:ok, %{"unit" => to_string(unit_name), "value" => to_string(value)}}
     end
 
     def dump(_) do
       :error
     end
-
   end
 end

--- a/lib/cldr/unit/ecto/unit_with_usage_ecto_map_type.ex
+++ b/lib/cldr/unit/ecto/unit_with_usage_ecto_map_type.ex
@@ -18,11 +18,11 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     @behaviour Ecto.Type
 
-    defdelegate cast(money), to: Cldr.Unit.Ecto.Composite.Type
+    defdelegate cast(unit), to: Cldr.Unit.Ecto.Composite.Type
 
     # New for ecto_sql 3.2
-    defdelegate  embed_as(term), to: Cldr.Unit.Ecto.Composite.Type
-    defdelegate  equal?(term1, term2), to: Cldr.Unit.Ecto.Composite.Type
+    defdelegate embed_as(term), to: Cldr.Unit.Ecto.Composite.Type
+    defdelegate equal?(term1, term2), to: Cldr.Unit.Ecto.Composite.Type
 
     def type() do
       :map
@@ -68,12 +68,11 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     def dump(%Cldr.Unit{unit: unit_name, value: value, usage: usage}) do
       {:ok,
-        %{"unit" => to_string(unit_name), "value" => to_string(value), "usage" => to_string(usage)}}
+       %{"unit" => to_string(unit_name), "value" => to_string(value), "usage" => to_string(usage)}}
     end
 
     def dump(_) do
       :error
     end
-
   end
 end


### PR DESCRIPTION
This PR adds a new case to equal?/2 function in `Cldr.Unit.Ecto.Composite.Type`
Can the module `Cldr.UnitWithUsage.Ecto.Composite.Type` also use it? As far as it's written in the [compare](https://hexdocs.pm/ex_cldr_units/Cldr.Unit.html#compare/2) documentation the usage field is not used.