### PR TITLE
Fix missing Jason.Encoder protocol for dump()

### DIFF
--- a/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
@@ -18,7 +18,7 @@ if Code.ensure_loaded?(Ecto.Type) do
       false
     end
 
-    def load({unit_name, unit_value}) do
+    def load(%{unit_name, unit_value}) do
       with {:ok, unit} <- Cldr.Unit.new(unit_name, unit_value) do
         {:ok, unit}
       else

--- a/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
@@ -67,7 +67,7 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't parse value #{inspect value}"}
+        :error -> {:error, message: "Couldn't parse value #{inspect(value)}"}
       end
     end
 
@@ -77,7 +77,7 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't cast value #{inspect value}"}
+        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
       end
     end
 

--- a/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
@@ -18,8 +18,8 @@ if Code.ensure_loaded?(Ecto.Type) do
       false
     end
 
-    def load(%{unit_name, unit_value}) do
-      with {:ok, unit} <- Cldr.Unit.new(unit_name, unit_value) do
+    def load(%{unit: unit, value: value}) do
+      with {:ok, unit} <- Cldr.Unit.new(unit, value) do
         {:ok, unit}
       else
         _ -> :error
@@ -55,7 +55,7 @@ if Code.ensure_loaded?(Ecto.Type) do
            {:ok, unit} <- Cldr.Unit.new(unit_name, decimal_value) do
         {:ok, unit}
       else
-        :error -> {:error, message: "Couldn't cast value #{inspect value}"}
+        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
         {:error, {_, message}} -> {:error, message: message}
       end
     end
@@ -77,7 +77,7 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't cast value #{inspect value}"}
+        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
       end
     end
 

--- a/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
@@ -29,13 +29,9 @@ if Code.ensure_loaded?(Ecto.Type) do
     # Dumping to the database.  We make the assumption that
     # since we are dumping from %Cldr.Unit{} structs that the
     # data is ok
-    def dump(%Cldr.Unit{value: %Ratio{} = value} = unit) do
-      value = Decimal.div(Decimal.new(value.numerator), Decimal.new(value.denominator))
-      {:ok, {to_string(unit.unit), value}}
-    end
 
     def dump(%Cldr.Unit{} = unit) do
-      {:ok, {to_string(unit.unit), unit.value}}
+      {:ok, unit}
     end
 
     def dump(_) do

--- a/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
@@ -18,7 +18,7 @@ if Code.ensure_loaded?(Ecto.Type) do
       false
     end
 
-    def load(%{unit: unit, value: value}) do
+    def load(%{"unit" => unit, "value" => value}) do
       with {:ok, unit} <- Cldr.Unit.new(unit, value) do
         {:ok, unit}
       else

--- a/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_ecto_composite_type.ex
@@ -67,7 +67,7 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't parse value #{inspect(value)}"}
+        :error -> {:error, message: "Couldn't parse value #{inspect value}"}
       end
     end
 
@@ -77,7 +77,7 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
+        :error -> {:error, message: "Couldn't cast value #{inspect value}"}
       end
     end
 

--- a/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
@@ -1,5 +1,5 @@
 if Code.ensure_loaded?(Ecto.Type) do
-  defmodule Cldr.UnitWithUsage.Ecto.Composite.Type do
+  defmodule Cldr.Unit.Ecto.Composite.Type do
     @moduledoc """
     Implements the Ecto.Type behaviour for a user-defined Postgres composite type
     called `:cldr_unit`.
@@ -11,23 +11,15 @@ if Code.ensure_loaded?(Ecto.Type) do
     @behaviour Ecto.Type
 
     def type do
-      :cldr_unit_with_usage
+      :cldr_unit
     end
 
     def blank?(_) do
       false
     end
 
-    def load({unit_name, unit_value, nil}) do
-      with {:ok, unit} <- Cldr.Unit.new(unit_name, unit_value) do
-        {:ok, unit}
-      else
-        _ -> :error
-      end
-    end
-
-    def load({unit_name, unit_value, unit_usage}) do
-      with {:ok, unit} <- Cldr.Unit.new(unit_name, unit_value, usage: unit_usage) do
+    def load(%{unit: unit, value: value}) do
+      with {:ok, unit} <- Cldr.Unit.new(unit, value) do
         {:ok, unit}
       else
         _ -> :error
@@ -56,39 +48,40 @@ if Code.ensure_loaded?(Ecto.Type) do
       {:ok, nil}
     end
 
-    def cast(%{"unit" => unit_name, "value" => value, "usage" => usage})
+    def cast(%{"unit" => unit_name, "value" => value})
         when (is_binary(unit_name) or is_atom(unit_name)) and is_number(value) do
       with decimal_value <- Decimal.new(value),
-           {:ok, unit} <- Cldr.Unit.new(unit_name, decimal_value, usage: usage) do
+           {:ok, unit} <- Cldr.Unit.new(unit_name, decimal_value) do
         {:ok, unit}
       else
+        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't cast value #{inspect value}"}
       end
     end
 
-    def cast(%{"unit" => unit_name, "value" => value, "usage" => usage})
+    def cast(%{"unit" => unit_name, "value" => value})
         when (is_binary(unit_name) or is_atom(unit_name)) and is_binary(value) do
       with {value, ""} <- Cldr.Decimal.parse(value),
-           {:ok, unit} <- Cldr.Unit.new(unit_name, value, usage: usage) do
+           {:ok, unit} <- Cldr.Unit.new(unit_name, value) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't parse value #{inspect value}"}
+        :error -> {:error, message: "Couldn't parse value #{inspect(value)}"}
       end
     end
 
-    def cast(%{"unit" => unit_name, "value" => %Decimal{} = value, "usage" => usage})
+    def cast(%{"unit" => unit_name, "value" => %Decimal{} = value})
         when is_binary(unit_name) or is_atom(unit_name) do
-      with {:ok, unit} <- Cldr.Unit.new(unit_name, value, usage: usage) do
+      with {:ok, unit} <- Cldr.Unit.new(unit_name, value) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
+        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
       end
     end
 
-    def cast(%{unit: unit_name, value: value} = unit) do
-      cast(%{"unit" => unit_name, "value" => value, "usage" => unit.usage})
+    def cast(%{unit: unit_name, value: value}) do
+      cast(%{"unit" => unit_name, "value" => value})
     end
 
     def cast(_money) do

--- a/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
@@ -1,5 +1,5 @@
 if Code.ensure_loaded?(Ecto.Type) do
-  defmodule Cldr.Unit.Ecto.Composite.Type do
+  defmodule Cldr.UnitWithUsage.Ecto.Composite.Type do
     @moduledoc """
     Implements the Ecto.Type behaviour for a user-defined Postgres composite type
     called `:cldr_unit`.
@@ -11,15 +11,23 @@ if Code.ensure_loaded?(Ecto.Type) do
     @behaviour Ecto.Type
 
     def type do
-      :cldr_unit
+      :cldr_unit_with_usage
     end
 
     def blank?(_) do
       false
     end
 
-    def load(%{unit: unit, value: value}) do
-      with {:ok, unit} <- Cldr.Unit.new(unit, value) do
+    def load({unit_name, unit_value, nil}) do
+      with {:ok, unit} <- Cldr.Unit.new(unit_name, unit_value) do
+        {:ok, unit}
+      else
+        _ -> :error
+      end
+    end
+
+    def load({unit_name, unit_value, unit_usage}) do
+      with {:ok, unit} <- Cldr.Unit.new(unit_name, unit_value, usage: unit_usage) do
         {:ok, unit}
       else
         _ -> :error
@@ -29,8 +37,13 @@ if Code.ensure_loaded?(Ecto.Type) do
     # Dumping to the database.  We make the assumption that
     # since we are dumping from %Cldr.Unit{} structs that the
     # data is ok
+    def dump(%Cldr.Unit{value: %Ratio{} = value} = unit) do
+      value = Decimal.div(Decimal.new(value.numerator), Decimal.new(value.denominator))
+      {:ok, {to_string(unit.unit), value, to_string(unit.usage)}}
+    end
+
     def dump(%Cldr.Unit{} = unit) do
-      {:ok, unit}
+      {:ok, {to_string(unit.unit), unit.value, to_string(unit.usage)}}
     end
 
     def dump(_) do
@@ -48,21 +61,21 @@ if Code.ensure_loaded?(Ecto.Type) do
       {:ok, nil}
     end
 
-    def cast(%{"unit" => unit_name, "value" => value})
+    def cast(%{"unit" => unit_name, "value" => value, "usage" => usage})
         when (is_binary(unit_name) or is_atom(unit_name)) and is_number(value) do
       with decimal_value <- Decimal.new(value),
-           {:ok, unit} <- Cldr.Unit.new(unit_name, decimal_value) do
+           {:ok, unit} <- Cldr.Unit.new(unit_name, decimal_value, usage: usage) do
         {:ok, unit}
       else
-        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
         {:error, {_, message}} -> {:error, message: message}
+        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
       end
     end
 
-    def cast(%{"unit" => unit_name, "value" => value})
+    def cast(%{"unit" => unit_name, "value" => value, "usage" => usage})
         when (is_binary(unit_name) or is_atom(unit_name)) and is_binary(value) do
       with {value, ""} <- Cldr.Decimal.parse(value),
-           {:ok, unit} <- Cldr.Unit.new(unit_name, value) do
+           {:ok, unit} <- Cldr.Unit.new(unit_name, value, usage: usage) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
@@ -70,18 +83,17 @@ if Code.ensure_loaded?(Ecto.Type) do
       end
     end
 
-    def cast(%{"unit" => unit_name, "value" => %Decimal{} = value})
+    def cast(%{"unit" => unit_name, "value" => %Decimal{} = value, "usage" => usage})
         when is_binary(unit_name) or is_atom(unit_name) do
-      with {:ok, unit} <- Cldr.Unit.new(unit_name, value) do
+      with {:ok, unit} <- Cldr.Unit.new(unit_name, value, usage: usage) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
       end
     end
 
-    def cast(%{unit: unit_name, value: value}) do
-      cast(%{"unit" => unit_name, "value" => value})
+    def cast(%{unit: unit_name, value: value} = unit) do
+      cast(%{"unit" => unit_name, "value" => value, "usage" => unit.usage})
     end
 
     def cast(_money) do

--- a/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
@@ -37,11 +37,6 @@ if Code.ensure_loaded?(Ecto.Type) do
     # Dumping to the database.  We make the assumption that
     # since we are dumping from %Cldr.Unit{} structs that the
     # data is ok
-    def dump(%Cldr.Unit{value: %Ratio{} = value} = unit) do
-      value = Decimal.div(Decimal.new(value.numerator), Decimal.new(value.denominator))
-      {:ok, {to_string(unit.unit), value, to_string(unit.usage)}}
-    end
-
     def dump(%Cldr.Unit{} = unit) do
       {:ok, unit}
     end

--- a/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
@@ -43,7 +43,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     end
 
     def dump(%Cldr.Unit{} = unit) do
-      {:ok, {to_string(unit.unit), unit.value, to_string(unit.usage)}}
+      {:ok, unit}
     end
 
     def dump(_) do

--- a/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
+++ b/lib/cldr/unit/ecto/unit_with_usage_ecto_composite_type.ex
@@ -68,7 +68,7 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't cast value #{inspect(value)}"}
+        :error -> {:error, message: "Couldn't cast value #{inspect value}"}
       end
     end
 
@@ -79,7 +79,7 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:ok, unit}
       else
         {:error, {_, message}} -> {:error, message: message}
-        :error -> {:error, message: "Couldn't parse value #{inspect(value)}"}
+        :error -> {:error, message: "Couldn't parse value #{inspect value}"}
       end
     end
 


### PR DESCRIPTION
Currently, the library tries to dump a tuple, which results in a json encoding error.

> ** (Protocol.UndefinedError) protocol Jason.Encoder not implemented for {"gram", 7145} of type Tuple, Jason.Encoder protocol must always be explicitly implemented. 

# Solution
`%Cldr.Unit{}` implements `Jason.Encoder` already, no need for the tuple.

https://github.com/elixir-cldr/cldr_units/tree/master/lib/cldr/protocol/jason

An alternative solution is to convert the tuple to a list (`|> Tuple.to_list()`).

## Warning
`%Ratio{}` also implements `Jason.Encoder`, but I have not tested the functionality.

---

# Cldr.UnitWithUsage.Ecto.Composite.Type

The `Jason.Encoder` is not encoding `:usage` 😒 .  But this could be added easily.

https://github.com/elixir-cldr/cldr_units/blob/master/lib/cldr/protocol/jason/unit.ex#L6

